### PR TITLE
Add users URLs and clean root routing

### DIFF
--- a/ArticleSite/urls.py
+++ b/ArticleSite/urls.py
@@ -16,7 +16,7 @@ Including another URLconf
 """
 
 from django.contrib import admin
-from django.urls import path, include
+from django.urls import include, path
 from rest_framework import routers
 from articles.views import ArticleViewSet
 from comments.views import CommentViewSet
@@ -24,15 +24,13 @@ from likes.views import LikeViewSet
 
 
 router = routers.DefaultRouter()
-router.register(r'articles', ArticleViewSet)
-router.register(r'comments', CommentViewSet)
-router.register(r'likes', LikeViewSet)
+router.register(r"articles", ArticleViewSet)
+router.register(r"comments", CommentViewSet)
+router.register(r"likes", LikeViewSet)
 
 urlpatterns = [
-    path('admin/', admin.site.urls),
-    path('', include('articles.urls')),
-    path('api/', include(router.urls)),
-
     path("admin/", admin.site.urls),
     path("articles/", include("articles.urls")),
+    path("", include("users.urls")),
+    path("api/", include(router.urls)),
 ]

--- a/users/urls.py
+++ b/users/urls.py
@@ -1,0 +1,11 @@
+from django.urls import path
+from . import views
+
+app_name = "users"
+
+urlpatterns = [
+    path("", views.index, name="index"),
+    path("like/<int:article_id>/", views.like_article, name="like_article"),
+    path("comment/<int:article_id>/", views.add_comment, name="add_comment"),
+    path("users/", views.users_list, name="users_list"),
+]


### PR DESCRIPTION
## Summary
- Remove duplicate admin URL entry and consolidate article routes under `/articles/`
- Introduce `users.urls` with routes for index, likes, comments and listing users
- Wire up `users` URLs at the project root

## Testing
- `pytest`
- ⚠️ `python manage.py test` (ImportError: Couldn't import Django)

------
https://chatgpt.com/codex/tasks/task_e_689f480649b08333941772e5e7683370